### PR TITLE
Add `-c toplevel=true` to Terser

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint:js": "npx eslint './src/*.mjs' --fix && npx eslint './demo/*.mjs' --fix",
     "lint:css": "cp ./src/template-contents.tpl ./src/template-contents.html && npx stylelint './src/*.html' --fix && cp ./src/template-contents.html ./src/template-contents.tpl && rm ./src/template-contents.html && npx stylelint './demo/*.css' --fix",
     "lint": "npm run lint:js && npm run lint:css",
-    "build": "npm run clean && npx terser ./src/dark-mode-toggle.mjs -m toplevel=true --comments /@license/ --ecma=8 -o ./dist/dark-mode-toggle.min.mjs",
+    "build": "npm run clean && npx terser ./src/dark-mode-toggle.mjs -m toplevel=true -c toplevel=true --mangle-props --comments /@license/ --ecma=8 -o ./dist/dark-mode-toggle.min.mjs",
     "prepare": "npm run lint && npm run build"
   },
   "repository": {


### PR DESCRIPTION
This allows to compress top-level statements and not just names.

Raw / gzip sizes:
Before: 8393 / 2570 bytes
After:  6907 / 2397 bytes