### PR TITLE
Correct routes for unstyled and built variants

### DIFF
--- a/demo/dist.html
+++ b/demo/dist.html
@@ -63,7 +63,7 @@
         </fieldset>
       </form>
       <p>
-        Also see the <a href="/demo/unstyled.html">unstyled variant</a>
+        Also see the <a href="unstyled.html">unstyled variant</a>
         that shows the out-of-the-box experience.
       </p>
     </main>

--- a/demo/index.html
+++ b/demo/index.html
@@ -63,11 +63,11 @@
         </fieldset>
       </form>
       <p>
-        Also see the <a href="/demo/unstyled.html">unstyled variant</a>
+        Also see the <a href="unstyled.html">unstyled variant</a>
         that shows the out-of-the-box experience.
       </p>
       <p>
-        Run <code>npm run build</code> and see the <a href="/demo/dist.html">built variant</a>
+        Run <code>npm run build</code> and see the <a href="dist.html">built variant</a>
         that uses the minified version of the script in the <code>dist</code> folder.
       </p>
     </main>


### PR DESCRIPTION
An absolute URL leads to a 404 because the full route includes /dark-mode-toggle/

Demo: https://zarthus.github.io/dark-mode-toggle/demo/