### PR TITLE
Fix path for "exports"

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/dark-mode-toggle.mjs",
   "browser": "dist/dark-mode-toggle.min.mjs",
   "module": "dist/dark-mode-toggle.min.mjs",
-  "exports": "dist/dark-mode-toggle.min.mjs",
+  "exports": "./dist/dark-mode-toggle.min.mjs",
   "unpkg": "dist/dark-mode-toggle.min.mjs",
   "types": "src/dark-mode-toggle.d.ts",
   "files": [


### PR DESCRIPTION
> All paths defined in the "exports" must be relative file URLs starting with ./.

As required by [Packages Exports](https://nodejs.org/api/packages.html#packages_exports) in the Node documentation and the package.json schema.

This fixes [snowpack](https://www.snowpack.dev/) builds failing and probably builds using es modules with other build tools as well (I have only tested snowpack).