### PR TITLE
Fix link to dark-mode-toggle-stylesheets-loader.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ script as follows:
       media="(prefers-color-scheme: dark)"
     />
   </noscript>
-  <script src="https://googlechromelabs.github.io/dark-mode-toggle/src/dark-mode-toggle-stylesheets-loader.min.js"></script>
+  <script src="https://googlechromelabs.github.io/dark-mode-toggle/src/dark-mode-toggle-stylesheets-loader.js"></script>
   <script
     type="module"
     src="https://googlechromelabs.github.io/dark-mode-toggle/src/dark-mode-toggle.mjs"


### PR DESCRIPTION
The minified version was removed in https://github.com/GoogleChromeLabs/dark-mode-toggle/commit/3e60d20098362e65ff7c67975c5465471a0bf018.