### PR TITLE
Fix ariaLabel typo

### DIFF
--- a/src/dark-mode-toggle.mjs
+++ b/src/dark-mode-toggle.mjs
@@ -445,7 +445,7 @@ export class DarkModeToggle extends HTMLElement {
   _updateThreeWayRadios() {
     this._lightThreeWayLabel.ariaLabel = LIGHT;
     this._systemThreeWayLabel.ariaLabel = SYSTEM;
-    this._lightThreeWayLabel.ariaLabel = DARK;
+    this._darkThreeWayLabel.ariaLabel = DARK;
     this._lightThreeWayLabel.textContent = this.light;
     this._systemThreeWayLabel.textContent = this.system;
     this._darkThreeWayLabel.textContent = this.dark;


### PR DESCRIPTION
This is flagged by Lighthouse when running a11y check. Fix the typo by properly assigning the dark label to the ...dark label.